### PR TITLE
Fix github search link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Finding projects depends on how the search API is structured for every hosting
 platform. For example, you can find all `publiccode.yml` on GitHub files by
 searching using the frontend or the API.
 
-* [GitHub Search `filename:publiccode.yml
-  path:/`](https://github.com/search?q=filename%3Apubliccode.yml+path%3A%2F)
+* [GitHub Search `path: /^publiccode.yml$/`](https://github.com/search?q=path%3A%2F%5Epubliccode.yml%24%2F&type=code)
 
 The Italian Digital Transformation Team is also working on providing a scanner
 which looks for all publiccode files on all publicly accessible websites, and


### PR DESCRIPTION
## Title

## Content

This fixes the github search link to find all Repositories which have a `publiccode.yml`.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [ ] Italian version
- [x] English version